### PR TITLE
#9 The downloaded torrent filename is the torrent title instead of the original torrent file name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "torrust-index-types-lib",
-  "version": "0.1.4",
+  "version": "0.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "torrust-index-types-lib",
-      "version": "0.1.4",
+      "version": "0.3.0",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^4.9.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "torrust-index-types-lib",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Contains common types for the Torrust project.",
   "repository": "https://github.com/torrust/torrust-index-types-lib",
   "license" : "SEE LICENSE IN COPYRIGHT",

--- a/src/types/torrent.ts
+++ b/src/types/torrent.ts
@@ -16,6 +16,7 @@ export type TorrentResponse = {
     trackers: Array<string>
     magnet_link: string
     tags: Array<TorrentTag>
+    name: string
 }
 
 export type TorrentListing = {
@@ -29,6 +30,7 @@ export type TorrentListing = {
     file_size: number
     leechers: number
     seeders: number
+    name: string
 }
 
 export type TorrentFile = {


### PR DESCRIPTION
Resolves #9 